### PR TITLE
Drop IE 8

### DIFF
--- a/data.json
+++ b/data.json
@@ -6,7 +6,7 @@
     "baselineVersions": {
         "edge": "*",
         "edge_mob": "*",
-        "ie": "8",
+        "ie": "9",
         "ie_mob": "11",
         "chrome": "29",
         "safari": "9",

--- a/lib/normalise-user-agent.vcl
+++ b/lib/normalise-user-agent.vcl
@@ -1799,7 +1799,7 @@ sub normalise_user_agent_1_10_1 {
             !req.http.Host || 
             (req.http.normalized_user_agent_family == "edge") || 
             (req.http.normalized_user_agent_family == "edge_mob") || 
-            (req.http.normalized_user_agent_family == "ie" && std.atoi(req.http.normalized_user_agent_major_version) >= 8) || 
+            (req.http.normalized_user_agent_family == "ie" && std.atoi(req.http.normalized_user_agent_major_version) >= 9) || 
             (req.http.normalized_user_agent_family == "ie_mob" && std.atoi(req.http.normalized_user_agent_major_version) >= 11) || 
             (req.http.normalized_user_agent_family == "chrome" && std.atoi(req.http.normalized_user_agent_major_version) >= 29) || 
             (req.http.normalized_user_agent_family == "safari" && std.atoi(req.http.normalized_user_agent_major_version) >= 9) || 

--- a/test/integration/normalise-user-agent-test-cases.json
+++ b/test/integration/normalise-user-agent-test-cases.json
@@ -127,10 +127,6 @@
         "output": "other/0.0.0"
     },
     {
-        "input": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; chromeframe; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729)",
-        "output": "ie/8.0.0"
-    },
-    {
         "input": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; chromeframe; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Sleipnir 2.8.5)3.0.30729)",
         "output": "other/0.0.0"
     },
@@ -279,10 +275,6 @@
         "output": "other/0.0.0"
     },
     {
-        "input": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; .NET CLR 2.0.50727; .NET CLR 1.1.4322)",
-        "output": "ie/8.0.0"
-    },
-    {
         "input": "Mozilla/4.0 WebTV/2.6 (compatible; MSIE 4.0)",
         "output": "other/0.0.0"
     },
@@ -293,10 +285,6 @@
     {
         "input": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0)",
         "output": "ie/10.0.0"
-    },
-    {
-        "input": "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; GTB6; chromeframe; .NET CLR 2.0.50727; .NET CLR 1.1.4322; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)",
-        "output": "ie/8.0.0"
     },
     {
         "input": "Java/1.6.0_43",

--- a/test/unit/node.test.js
+++ b/test/unit/node.test.js
@@ -206,7 +206,7 @@ describe("lib/UA", function () {
       proclaim.equal(ieLargeScreen.ua.family, "ie");
 
       const ie = new UA(
-        "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; chromeframe; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729)"
+        "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; InfoPath.3)"
       );
       proclaim.equal(ie.ua.family, "ie");
 
@@ -411,6 +411,7 @@ describe("lib/UA", function () {
 
       proclaim.equal(new UA("ie/6").isUnknown(), true);
       proclaim.equal(new UA("ie/7").isUnknown(), true);
+      proclaim.equal(new UA("ie/8").isUnknown(), true);
       proclaim.equal(new UA("ie/14").isUnknown(), false);
 
       proclaim.equal(new UA("ie_mob/7").isUnknown(), true);


### PR DESCRIPTION
This PR removes IE 8 from the list of baseline versions. This is a breaking change that should be accompanied by a major version bump.

Resolves https://github.com/Financial-Times/polyfill-useragent-normaliser/issues/172.